### PR TITLE
Add impl of std::error::Error and default formatter

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@ use std::io::ErrorKind;
 pub use std::io::Error as IoError;
 pub use std::io::Result as IoResult;
 use std::convert::TryFrom;
+use std::error;
+use std::fmt;
 
 // Export types
 
@@ -67,6 +69,20 @@ impl From<IoError> for Error {
     }
 }
 
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            Error::Io(ref err) => Some(err),
+            _                  => None,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", <Self as error::Error>::description(self))
+    }
+}
 
 /// Return error on invalid range.
 #[inline]

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,7 +80,12 @@ impl error::Error for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        match self {
+            Error::Io(err) => err.fmt(f),
+            Error::NotSupported(message) => write!(f, "not supported: {}", message),
+            Error::Invalid(message) => write!(f, "invalid: {}", message),
+            _ => write!(f, "{}", self),
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,7 +80,7 @@ impl error::Error for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", <Self as error::Error>::description(self))
+        write!(f, "{}", self)
     }
 }
 


### PR DESCRIPTION
fixes #39 

This PR adds an impl for std::error::Errror and the default formatter.

Only the IoError is handled since the other are types `Cow<'static, str>` (I'm not sure why they aren't just String). Let me know what you think. I am not able to test it as the changes on the master branch break a lot of things from 0.7.3. 