### PR TITLE
Fully working Huffman

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,6 @@ dependencies = [
  "image 0.23.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lebe 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "min-max-heap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -229,11 +228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "min-max-heap"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "miniz_oxide"
@@ -493,7 +487,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-"checksum min-max-heap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2687e6cf9c00f48e9284cf9fd15f2ef341d03cc7743abf9df4c5f07fdee50b18"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ half = "1.6.0"        # 16 bit float pixel data type
 bit_field = "0.10.0"  # exr file version bit flags
 deflate = "0.8.4"     # DEFLATE compression
 inflate = "0.4.5"     # DEFLATE decompression
-min-max-heap = "1.3.0"# MinHeap used for Huffman compression
 smallvec = "1.3.0"    # make cache friendly allocations             TODO profile if smallvec is really an improvement!
 rayon = "1.3.0"       # multi-core compression and decompression     TODO make this an optional feature?
 


### PR DESCRIPTION
Fixed the min-heap that was causing issues in some cases, when the frequencies were not ordered by frequency. This is a much more robust version and behaves the same way as the make_heap with a custom comparator.
Added some more test, with bigger buffers, and multiple calls to compress, uncompress, since before sometimes tests passed on special cases (ordered frequencies).