### PR TITLE
remove unnecessary semicolons

### DIFF
--- a/examples/1_rgb_exr_to_png.rs
+++ b/examples/1_rgb_exr_to_png.rs
@@ -43,7 +43,7 @@ fn main() {
         // TODO does the `image` crate expect gamma corrected data?
         let clamped = (linear - 0.5).tanh() * 0.5 + 0.5;
         (clamped * 255.0) as u8
-    };
+    }
 
     // save the png buffer to a png file
     let png_buffer = &image.layer_data.channel_data.pixels;

--- a/examples/2_rgba_exposure_adjust.rs
+++ b/examples/2_rgba_exposure_adjust.rs
@@ -14,7 +14,7 @@ fn main() {
     // This struct trades sub-optimal memory-efficiency for clarity,
     // because this is an example, and does not have to be perfectly efficient.
     #[derive(Debug, PartialEq)]
-    struct CustomPixels { lines: Vec<Vec<RgbaF32Pixel>> };
+    struct CustomPixels { lines: Vec<Vec<RgbaF32Pixel>> }
     type RgbaF32Pixel = (f32, f32, f32, f32);
 
     // read the image from a file

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -26,7 +26,7 @@ fn check_files<T>(
     operation: impl Sync + std::panic::RefUnwindSafe + Fn(&Path) -> exr::error::Result<T>
 ) {
     #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-    enum Result { Ok, Skipped, Unsupported(String), Error(String) };
+    enum Result { Ok, Skipped, Unsupported(String), Error(String) }
 
     let files: Vec<PathBuf> = exr_files().collect();
     let mut results: Vec<(PathBuf, Result)> = files.into_par_iter()


### PR DESCRIPTION
Those semicolons seems to be useless and some of them prevents compilation (rust 1.51).