### PR TITLE
change assert to debug_assert

### DIFF
--- a/benches/write.rs
+++ b/benches/write.rs
@@ -47,7 +47,7 @@ fn write_parallel_zip16_to_buffered(bench: &mut Bencher) {
 fn write_uncompressed_to_buffered(bench: &mut Bencher) {
     let path = "tests/images/valid/custom/crowskull/crow_uncompressed.exr";
     let image = read_all_flat_layers_from_file(path).unwrap();
-    assert!(image.layer_data.iter().all(|layer| layer.encoding.compression == Compression::Uncompressed));
+    debug_assert!(image.layer_data.iter().all(|layer| layer.encoding.compression == Compression::Uncompressed));
 
     bench.iter(||{
         let mut result = Vec::new();

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -166,8 +166,8 @@ impl Compression {
     pub fn compress_image_section(self, header: &Header, mut uncompressed: ByteVec, pixel_section: IntegerBounds) -> Result<ByteVec> {
         let max_tile_size = header.max_block_pixel_size();
 
-        assert!(pixel_section.validate(Some(max_tile_size)).is_ok(), "decompress tile coordinate bug");
-        if header.deep { assert!(self.supports_deep_data()) }
+        debug_assert!(pixel_section.validate(Some(max_tile_size)).is_ok(), "decompress tile coordinate bug");
+        if header.deep { debug_assert!(self.supports_deep_data()) }
 
         // convert data if compression method expects native format
         // see https://github.com/AcademySoftwareFoundation/openexr/blob/3bd93f85bcb74c77255f28cdbb913fdbfbb39dfe/OpenEXR/IlmImf/ImfTiledOutputFile.cpp#L750-L842
@@ -204,8 +204,8 @@ impl Compression {
     pub fn decompress_image_section(self, header: &Header, compressed: ByteVec, pixel_section: IntegerBounds, pedantic: bool) -> Result<ByteVec> {
         let max_tile_size = header.max_block_pixel_size();
 
-        assert!(pixel_section.validate(Some(max_tile_size)).is_ok(), "decompress tile coordinate bug");
-        if header.deep { assert!(self.supports_deep_data()) }
+        debug_assert!(pixel_section.validate(Some(max_tile_size)).is_ok(), "decompress tile coordinate bug");
+        if header.deep { debug_assert!(self.supports_deep_data()) }
 
         let expected_byte_size = pixel_section.size.area() * header.channels.bytes_per_pixel; // FIXME this needs to account for subsampling anywhere
 


### PR DESCRIPTION
assert!() macros are always checked in both debug and release builds, and cannot be disabled, so we change them for debug_assert!() macros.

https://doc.rust-lang.org/std/macro.assert.html

I don't see any reason to keep those asserts in release builds (but maybe there is a good one so feel free to close the PR).
