### PR TITLE
rename meta::Blocks to meta::BlockDescription

### DIFF
--- a/examples/7_custom_write.rs
+++ b/examples/7_custom_write.rs
@@ -48,7 +48,7 @@ fn main() {
     let mut header = header.with_encoding(
         Compression::Uncompressed,
 
-        exr::meta::Blocks::Tiles(TileDescription {
+        exr::meta::BlockDescription::Tiles(TileDescription {
             tile_size: Vec2(64, 64),
             level_mode: LevelMode::Singular,
             rounding_mode: RoundingMode::Down

--- a/src/block/chunk.rs
+++ b/src/block/chunk.rs
@@ -196,7 +196,7 @@ impl TileCoordinates {
 
 
 
-use crate::meta::{MetaData, Blocks, calculate_block_size};
+use crate::meta::{MetaData, BlockDescription, calculate_block_size};
 
 impl ScanLineBlock {
 
@@ -365,12 +365,12 @@ impl Chunk {
             layer_index: layer_number,
             block: match header.blocks {
                 // flat data
-                Blocks::ScanLines if !header.deep => Block::ScanLine(ScanLineBlock::read(read, max_block_byte_size)?),
-                Blocks::Tiles(_) if !header.deep     => Block::Tile(TileBlock::read(read, max_block_byte_size)?),
+                BlockDescription::ScanLines if !header.deep => Block::ScanLine(ScanLineBlock::read(read, max_block_byte_size)?),
+                BlockDescription::Tiles(_) if !header.deep     => Block::Tile(TileBlock::read(read, max_block_byte_size)?),
 
                 // deep data
-                Blocks::ScanLines   => Block::DeepScanLine(DeepScanLineBlock::read(read, max_block_byte_size)?),
-                Blocks::Tiles(_)    => Block::DeepTile(DeepTileBlock::read(read, max_block_byte_size)?),
+                BlockDescription::ScanLines   => Block::DeepScanLine(DeepScanLineBlock::read(read, max_block_byte_size)?),
+                BlockDescription::Tiles(_)    => Block::DeepTile(DeepTileBlock::read(read, max_block_byte_size)?),
             },
         };
 

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -8,7 +8,7 @@ pub mod chunk;
 use crate::compression::{ByteVec, Compression};
 use crate::math::*;
 use crate::error::{Result, Error, usize_to_i32, UnitResult, u64_to_usize, usize_to_u64};
-use crate::meta::{MetaData, Blocks, TileIndices, OffsetTables, Headers};
+use crate::meta::{MetaData, BlockDescription, TileIndices, OffsetTables, Headers};
 use crate::block::chunk::{Chunk, Block, TileBlock, ScanLineBlock, TileCoordinates};
 use crate::meta::attribute::LineOrder;
 use rayon::prelude::ParallelBridge;
@@ -533,14 +533,14 @@ impl UncompressedBlock {
         Ok(Chunk {
             layer_index: index.layer,
             block : match header.blocks {
-                Blocks::ScanLines => Block::ScanLine(ScanLineBlock {
+                BlockDescription::ScanLines => Block::ScanLine(ScanLineBlock {
                     compressed_pixels: compressed_data,
 
                     // FIXME this calculation should not be made here but elsewhere instead (in meta::header?)
                     y_coordinate: usize_to_i32(index.pixel_position.y()) + header.own_attributes.layer_position.y(),
                 }),
 
-                Blocks::Tiles(_) => Block::Tile(TileBlock {
+                BlockDescription::Tiles(_) => Block::Tile(TileBlock {
                     compressed_pixels: compressed_data,
                     coordinates: tile_coordinates,
                 }),

--- a/src/image/read/layers.rs
+++ b/src/image/read/layers.rs
@@ -108,8 +108,8 @@ impl<C> LayerReader<C> {
                 compression: header.compression,
                 line_order: header.line_order,
                 blocks: match header.blocks {
-                    crate::meta::Blocks::ScanLines => Blocks::ScanLines,
-                    crate::meta::Blocks::Tiles(TileDescription { tile_size, .. }) => Blocks::Tiles(tile_size)
+                    crate::meta::BlockDescription::ScanLines => Blocks::ScanLines,
+                    crate::meta::BlockDescription::Tiles(TileDescription { tile_size, .. }) => Blocks::Tiles(tile_size)
                 },
             },
         })

--- a/src/image/read/levels.rs
+++ b/src/image/read/levels.rs
@@ -142,7 +142,7 @@ impl<S: ReadSamplesLevel> ReadSamples for ReadAllLevels<S> {
         let data_size = header.layer_size / channel.sampling;
 
         let levels = {
-            if let crate::meta::Blocks::Tiles(tiles) = &header.blocks {
+            if let crate::meta::BlockDescription::Tiles(tiles) = &header.blocks {
                 match tiles.level_mode {
                     LevelMode::Singular => Levels::Singular(self.read_samples.create_samples_level_reader(header, channel, Vec2(0,0), header.layer_size)?),
 

--- a/src/image/write/layers.rs
+++ b/src/image/write/layers.rs
@@ -75,10 +75,10 @@ fn slice_create_writer<'slf, Channels:'slf + WritableChannels<'slf>>(
 impl<'slf, Channels: WritableChannels<'slf>> WritableLayers<'slf> for Layer<Channels> {
     fn infer_headers(&self, image_attributes: &ImageAttributes) -> Headers {
         let blocks = match self.encoding.blocks {
-            crate::image::Blocks::ScanLines => crate::meta::Blocks::ScanLines,
+            crate::image::Blocks::ScanLines => crate::meta::BlockDescription::ScanLines,
             crate::image::Blocks::Tiles(tile_size) => {
                 let (level_mode, rounding_mode) = self.channel_data.infer_level_modes();
-                crate::meta::Blocks::Tiles(TileDescription { level_mode, rounding_mode, tile_size, })
+                crate::meta::BlockDescription::Tiles(TileDescription { level_mode, rounding_mode, tile_size, })
             },
         };
 

--- a/src/image/write/samples.rs
+++ b/src/image/write/samples.rs
@@ -5,7 +5,7 @@ use crate::meta::header::Header;
 use crate::block::lines::LineRefMut;
 use crate::image::{FlatSamples, Levels, RipMaps};
 use crate::math::{Vec2, RoundingMode};
-use crate::meta::{rip_map_levels, mip_map_levels, rip_map_indices, mip_map_indices, Blocks};
+use crate::meta::{rip_map_levels, mip_map_levels, rip_map_indices, mip_map_indices, BlockDescription};
 
 /// Enable an image with this sample grid to be written to a file.
 /// Also can contain multiple resolution levels.
@@ -139,8 +139,8 @@ impl<'samples, LevelSamples> WritableSamples<'samples> for Levels<LevelSamples>
     type Writer = LevelsWriter<LevelSamples::Writer>;
     fn create_samples_writer(&'samples self, header: &Header) -> Self::Writer {
         let rounding = match header.blocks {
-            Blocks::Tiles(TileDescription { rounding_mode, .. }) => Some(rounding_mode),
-            Blocks::ScanLines => None,
+            BlockDescription::Tiles(TileDescription { rounding_mode, .. }) => Some(rounding_mode),
+            BlockDescription::ScanLines => None,
         };
 
         LevelsWriter {

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -98,7 +98,7 @@ pub struct TileIndices {
 
 /// How the image pixels are split up into separate blocks.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Blocks {
+pub enum BlockDescription {
 
     /// The image is divided into scan line blocks.
     /// The number of scan lines in a block depends on the compression method.
@@ -135,12 +135,12 @@ pub enum Blocks {
     }
 }*/
 
-impl Blocks {
+impl BlockDescription {
 
     /// Whether this image is tiled. If false, this image is divided into scan line blocks.
     pub fn has_tiles(&self) -> bool {
         match self {
-            Blocks::Tiles { .. } => true,
+            BlockDescription::Tiles { .. } => true,
             _ => false
         }
     }
@@ -308,9 +308,9 @@ pub fn mip_map_indices(round: RoundingMode, max_resolution: Vec2<usize>) -> impl
 // If not multilayer and chunkCount not present,
 // the number of entries in the chunk table is computed
 // using the dataWindow and tileDesc attributes and the compression format
-pub fn compute_chunk_count(compression: Compression, data_size: Vec2<usize>, blocks: Blocks) -> usize {
+pub fn compute_chunk_count(compression: Compression, data_size: Vec2<usize>, blocks: BlockDescription) -> usize {
 
-    if let Blocks::Tiles(tiles) = blocks {
+    if let BlockDescription::Tiles(tiles) = blocks {
         let round = tiles.rounding_mode;
         let Vec2(tile_width, tile_height) = tiles.tile_size;
 
@@ -644,7 +644,7 @@ mod test {
             compression: Compression::Uncompressed,
             line_order: LineOrder::Increasing,
             deep_data_version: Some(1),
-            chunk_count: compute_chunk_count(Compression::Uncompressed, Vec2(2000, 333), Blocks::ScanLines),
+            chunk_count: compute_chunk_count(Compression::Uncompressed, Vec2(2000, 333), BlockDescription::ScanLines),
             max_samples_per_pixel: Some(4),
             shared_attributes: ImageAttributes {
                 pixel_aspect: 3.0,
@@ -654,7 +654,7 @@ mod test {
                 })
             },
 
-            blocks: Blocks::ScanLines,
+            blocks: BlockDescription::ScanLines,
             deep: false,
             layer_size: Vec2(2000, 333),
             own_attributes: LayerAttributes {
@@ -700,7 +700,7 @@ mod test {
             compression: Compression::Uncompressed,
             line_order: LineOrder::Increasing,
             deep_data_version: Some(1),
-            chunk_count: compute_chunk_count(Compression::Uncompressed, Vec2(2000, 333), Blocks::ScanLines),
+            chunk_count: compute_chunk_count(Compression::Uncompressed, Vec2(2000, 333), BlockDescription::ScanLines),
             max_samples_per_pixel: Some(4),
             shared_attributes: ImageAttributes {
                 pixel_aspect: 3.0,
@@ -709,7 +709,7 @@ mod test {
                     size: Vec2(11, 9)
                 })
             },
-            blocks: Blocks::ScanLines,
+            blocks: BlockDescription::ScanLines,
             deep: false,
             layer_size: Vec2(2000, 333),
             own_attributes: LayerAttributes {
@@ -747,7 +747,7 @@ mod test {
             compression: Compression::Uncompressed,
             line_order: LineOrder::Increasing,
             deep_data_version: Some(1),
-            chunk_count: compute_chunk_count(Compression::Uncompressed, Vec2(2000, 333), Blocks::ScanLines),
+            chunk_count: compute_chunk_count(Compression::Uncompressed, Vec2(2000, 333), BlockDescription::ScanLines),
             max_samples_per_pixel: Some(4),
             shared_attributes: ImageAttributes {
                 pixel_aspect: 3.0,
@@ -756,7 +756,7 @@ mod test {
                     size: Vec2(11, 9)
                 })
             },
-            blocks: Blocks::ScanLines,
+            blocks: BlockDescription::ScanLines,
             deep: false,
             layer_size: Vec2(2000, 333),
             own_attributes: LayerAttributes {


### PR DESCRIPTION
This to avoid confusion with image::Blocks which is similar but does not represent the same information.

This fix https://github.com/johannesvollmer/exrs/issues/127