### PR TITLE
specify standardized license and bump crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "exr"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "bencher",
  "bit_field",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ description = "Read and write OpenEXR files without any unsafe code"
 keywords = ["exr", "openexr", "file", "binary", "io"]
 categories = ["encoding", "filesystem", "graphics", "multimedia"]
 
-version = "1.4.1"
+version = "1.4.2"
 edition = "2018"
 authors = ["johannesvollmer <johannes596@t-online.de>"]
 
 repository = "https://github.com/johannesvollmer/exrs"
 readme = "README.md"
-license-file = "LICENSE.md"
+license = "BSD-3-Clause"
 exclude = [ "specification/*", "specification/**", "tests/images/*", "tests/images/**" ]
 
 [badges]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,30 +1,33 @@
 # Licenses
 
-This Rust implementation of the OpenEXR 
-and the the exrs crate are not affiliated with the 
+This Rust implementation of the OpenEXR image format
+and the exrs crate are not affiliated with the 
 [OpenEXR project](https://www.openexr.com/) or the 
 [ACADEMY SOFTWARE FOUNDATION](https://www.aswf.io/).
 
 
-## The OpenEXR File Format Specification, DreamWorks Compression Method: [BSD-3-Clause](https://github.com/AcademySoftwareFoundation/openexr/blob/master/LICENSE.md)
-Copyright Contributors to the OpenEXR Project. All rights reserved.
+## The OpenEXR Image Format: [BSD-3-Clause](https://github.com/AcademySoftwareFoundation/openexr/blob/master/LICENSE.md)
+Copyright (c) Contributors to the OpenEXR Project. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.   
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
-## The exrs Source Code: Also [BSD-3-Clause](https://github.com/AcademySoftwareFoundation/openexr/blob/master/LICENSE.md)
-Copyright Contributors to the exrs Project. All rights reserved.
+## The `exrs` Project, and independent Rust implementation of the official OpenEXR Image Format: Also [BSD-3-Clause](https://github.com/AcademySoftwareFoundation/openexr/blob/master/LICENSE.md)
+Copyright (c) Contributors to the exrs Project. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.   
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ __Big-endian code is not yet fully implemented. Help wanted.__
 Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
-exr = "1.4.1"
+exr = "1.4.2"
 
 # also, optionally add this to your crate for smaller binary size 
 # and better runtime performance

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,8 @@
 These are examples that demonstrate how to use `exrs`.
 
 The examples for any specific `exrs` version can be found on the `docs.rs` page:
-- [docs.rs/crate/exr/1.4.0/source/examples/](https://docs.rs/crate/exr/1.4.1/source/examples/)
+- [docs.rs/crate/exr/1.4.2/source/examples/](https://docs.rs/crate/exr/1.4.2/source/examples/)
+- [docs.rs/crate/exr/1.4.1/source/examples/](https://docs.rs/crate/exr/1.4.1/source/examples/)
 - [docs.rs/crate/exr/1.4.0/source/examples/](https://docs.rs/crate/exr/1.4.0/source/examples/)
 - [docs.rs/crate/exr/1.3.0/source/examples/](https://docs.rs/crate/exr/1.3.0/source/examples/)
 - [docs.rs/crate/exr/1.2.0/source/examples/](https://docs.rs/crate/exr/1.2.0/source/examples/)


### PR DESCRIPTION
License is now `BSD-3-Clause` in `cargo.toml`. However, we're still keeping a separate license file, to provide more detailed information about the relations between the `exrs` project and the `OpenEXR` standard.