### PR TITLE
Faster, more Rusty interleaving

### DIFF
--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -438,6 +438,9 @@ mod optimize_bytes {
         // Main loop that performs the interleaving
         for ((first, second), interleaved) in first_half_iter.iter().zip(second_half.iter())
             .zip(interleaved.chunks_exact_mut(2)) {
+                // The length of each chunk is known to be 2 at compile time,
+                // and each index is also a constant.
+                // This allows the compiler to remove the bounds checks.
                 interleaved[0] = *first;
                 interleaved[1] = *second;
         }


### PR DESCRIPTION
Massive speedups on reads across the board, with a 2x improvement on the `read_single_image_rle_all_channels` benchmark.

**Benchmarks:**

Before:
```
test read_single_image_non_parallel_zips_rgba        ... bench: 196,783,469 ns/iter (+/- 172,721)
test read_single_image_rle_all_channels              ... bench:  41,137,521 ns/iter (+/- 3,633,097)
test read_single_image_uncompressed_from_buffer_rgba ... bench:  33,522,367 ns/iter (+/- 70,401)
test read_single_image_uncompressed_rgba             ... bench:  37,435,859 ns/iter (+/- 2,202,515)
test read_single_image_zips_rgba                     ... bench:  71,419,820 ns/iter (+/- 4,860,501)
```

After:
```
test read_single_image_non_parallel_zips_rgba        ... bench: 150,670,222 ns/iter (+/- 10,422,001)
test read_single_image_rle_all_channels              ... bench:  21,199,353 ns/iter (+/- 4,196,646)
test read_single_image_uncompressed_from_buffer_rgba ... bench:  32,094,137 ns/iter (+/- 180,900)
test read_single_image_uncompressed_rgba             ... bench:  36,061,562 ns/iter (+/- 61,285)
test read_single_image_zips_rgba                     ... bench:  51,157,416 ns/iter (+/- 7,589,099)
```

**Profiles** on the `0c_read_rgba` example:

Before: https://share.firefox.dev/3PUnd5n

After: https://share.firefox.dev/3G2nzlM

As you can see, interleaving is down from taking up 58% to 14% of the time.

Most of the remaining time in interleaving is spent allocating and zeroing the Vec. Reusing the allocation can unlock further gains, at the cost of having to explicitly pass the Vec to the function for reuse. I can open a separate PR for that if you like.