### PR TITLE
Add non-parallel RLE read benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,10 @@ harness = false
 name = "write"
 harness = false
 
+[[bench]]
+name = "pixel_format_conversion"
+harness = false
+
 
 # recommended release settings for max runtime performance
 [profile.release]

--- a/benches/pixel_format_conversion.rs
+++ b/benches/pixel_format_conversion.rs
@@ -10,7 +10,7 @@ use std::io::Cursor;
 use exr::image::pixel_vec::PixelVec;
 
 /// Read an image from an in-memory buffer into its native f32 format
-fn read_image_rgba_without_conversion(bench: &mut Bencher) {
+fn read_image_rgba_f32_to_f32(bench: &mut Bencher) {
     let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
     bencher::black_box(&mut file);
 
@@ -61,7 +61,7 @@ fn read_image_rgba_f32_to_f16(bench: &mut Bencher) {
 }
 
 benchmark_group!(pixel_format_conversion,
-    read_image_rgba_without_conversion,
+    read_image_rgba_f32_to_f32,
     read_image_rgba_f32_to_u32,
     read_image_rgba_f32_to_f16,
 );

--- a/benches/pixel_format_conversion.rs
+++ b/benches/pixel_format_conversion.rs
@@ -1,0 +1,69 @@
+#[macro_use]
+extern crate bencher;
+
+extern crate exr;
+use exr::prelude::*;
+
+use bencher::Bencher;
+use std::fs;
+use std::io::Cursor;
+use exr::image::pixel_vec::PixelVec;
+
+/// Read an image from an in-memory buffer into its native f32 format
+fn read_image_rgba_without_conversion(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
+    bencher::black_box(&mut file);
+
+    bench.iter(||{
+        let image = exr::prelude::read()
+            .no_deep_data().largest_resolution_level()
+            .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
+            .all_layers().all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
+/// Read image and convert the samples to u32 (from native f32)
+fn read_image_rgba_f32_to_u32(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
+    bencher::black_box(&mut file);
+
+    bench.iter(||{
+        let image = exr::prelude::read()
+            .no_deep_data().largest_resolution_level()
+            .rgba_channels(PixelVec::<(u32,u32,u32,u32)>::constructor, PixelVec::set_pixel)
+            .all_layers().all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
+/// f16 is not natively supported by CPUs, which introduces unique performance pitfalls
+fn read_image_rgba_f32_to_f16(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
+    bencher::black_box(&mut file);
+
+    bench.iter(||{
+        let image = exr::prelude::read()
+            .no_deep_data().largest_resolution_level()
+            .rgba_channels(PixelVec::<(f16,f16,f16,f16)>::constructor, PixelVec::set_pixel)
+            .all_layers().all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
+benchmark_group!(pixel_format_conversion,
+    read_image_rgba_without_conversion,
+    read_image_rgba_f32_to_u32,
+    read_image_rgba_f32_to_f16,
+);
+
+benchmark_main!(pixel_format_conversion);

--- a/benches/profiling.rs
+++ b/benches/profiling.rs
@@ -25,9 +25,63 @@ fn read_single_image_all_channels(bench: &mut Bencher) {
     })
 }
 
+/// Read image from file
+fn read_single_image_from_buffer_all_channels(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
+    bencher::black_box(&mut file);
+
+    bench.iter(||{
+        let image = exr::prelude::read()
+            .no_deep_data().largest_resolution_level()
+            .all_channels()
+            .all_layers().all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
+
 /// Read image from in-memory buffer
 fn read_single_image_from_buffer_rgba_channels(bench: &mut Bencher) {
-    let file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
+    bencher::black_box(&mut file);
+
+    bench.iter(||{
+        let image = exr::prelude::read()
+            .no_deep_data().largest_resolution_level()
+            .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
+            .all_layers().all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
+/// Read image from in-memory buffer and convert the samples to u32 (from native f32)
+fn read_single_image_from_buffer_rgba_channels_to_u32(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
+    bencher::black_box(&mut file);
+
+    bench.iter(||{
+        let image = exr::prelude::read()
+            .no_deep_data().largest_resolution_level()
+            .rgba_channels(PixelVec::<(u32,u32,u32,u32)>::constructor, PixelVec::set_pixel)
+            .all_layers().all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
+/// Read image from in-memory buffer and convert the samples to u16 (from native f32)
+/// f16 is not natively supported by CPUs, which introduces unique performance pitfalls
+fn read_single_image_from_buffer_rgba_channels_to_f16(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
+    bencher::black_box(&mut file);
 
     bench.iter(||{
         let image = exr::prelude::read()
@@ -41,10 +95,12 @@ fn read_single_image_from_buffer_rgba_channels(bench: &mut Bencher) {
     })
 }
 
-
 benchmark_group!(profiling,
-    read_single_image_from_buffer_rgba_channels,
     read_single_image_all_channels,
+    read_single_image_from_buffer_all_channels,
+    read_single_image_from_buffer_rgba_channels,
+    read_single_image_from_buffer_rgba_channels_to_u32,
+    read_single_image_from_buffer_rgba_channels_to_f16,
 );
 
 benchmark_main!(profiling);

--- a/benches/profiling.rs
+++ b/benches/profiling.rs
@@ -7,7 +7,6 @@ use exr::prelude::*;
 use bencher::Bencher;
 use std::fs;
 use std::io::Cursor;
-use exr::image::pixel_vec::PixelVec;
 
 /// Read image from file
 fn read_single_image_all_channels(bench: &mut Bencher) {
@@ -42,65 +41,9 @@ fn read_single_image_from_buffer_all_channels(bench: &mut Bencher) {
     })
 }
 
-
-/// Read image from in-memory buffer
-fn read_single_image_from_buffer_rgba_channels(bench: &mut Bencher) {
-    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
-    bencher::black_box(&mut file);
-
-    bench.iter(||{
-        let image = exr::prelude::read()
-            .no_deep_data().largest_resolution_level()
-            .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
-            .all_layers().all_attributes()
-            .non_parallel()
-            .from_buffered(Cursor::new(file.as_slice())).unwrap();
-
-        bencher::black_box(image);
-    })
-}
-
-/// Read image from in-memory buffer and convert the samples to u32 (from native f32)
-fn read_single_image_from_buffer_rgba_channels_to_u32(bench: &mut Bencher) {
-    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
-    bencher::black_box(&mut file);
-
-    bench.iter(||{
-        let image = exr::prelude::read()
-            .no_deep_data().largest_resolution_level()
-            .rgba_channels(PixelVec::<(u32,u32,u32,u32)>::constructor, PixelVec::set_pixel)
-            .all_layers().all_attributes()
-            .non_parallel()
-            .from_buffered(Cursor::new(file.as_slice())).unwrap();
-
-        bencher::black_box(image);
-    })
-}
-
-/// Read image from in-memory buffer and convert the samples to u16 (from native f32)
-/// f16 is not natively supported by CPUs, which introduces unique performance pitfalls
-fn read_single_image_from_buffer_rgba_channels_to_f16(bench: &mut Bencher) {
-    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
-    bencher::black_box(&mut file);
-
-    bench.iter(||{
-        let image = exr::prelude::read()
-            .no_deep_data().largest_resolution_level()
-            .rgba_channels(PixelVec::<(f16,f16,f16,f16)>::constructor, PixelVec::set_pixel)
-            .all_layers().all_attributes()
-            .non_parallel()
-            .from_buffered(Cursor::new(file.as_slice())).unwrap();
-
-        bencher::black_box(image);
-    })
-}
-
 benchmark_group!(profiling,
     read_single_image_all_channels,
     read_single_image_from_buffer_all_channels,
-    read_single_image_from_buffer_rgba_channels,
-    read_single_image_from_buffer_rgba_channels_to_u32,
-    read_single_image_from_buffer_rgba_channels_to_f16,
 );
 
 benchmark_main!(profiling);

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -60,6 +60,24 @@ fn read_single_image_rle_all_channels(bench: &mut Bencher) {
     })
 }
 
+/// Read without multi-core RLE decompression
+fn read_single_image_rle_non_parallel_all_channels(bench: &mut Bencher) {
+    bench.iter(||{
+        let path = "tests/images/valid/custom/crowskull/crow_rle.exr";
+
+        // copied from `read_all_flat_layers_from_file` and added `.non_parallel()`
+        let image = exr::prelude::read()
+            .no_deep_data()
+            .largest_resolution_level()
+            .all_channels()
+            .all_layers()
+            .all_attributes()
+            .non_parallel()
+            .from_file(path).unwrap();
+        bencher::black_box(image);
+    })
+}
+
 /// Read without multi-core ZIP decompression
 fn read_single_image_non_parallel_zips_rgba(bench: &mut Bencher) {
     bench.iter(||{
@@ -82,6 +100,7 @@ benchmark_group!(read,
     read_single_image_uncompressed_rgba,
     read_single_image_zips_rgba,
     read_single_image_rle_all_channels,
+    read_single_image_rle_non_parallel_all_channels,
     read_single_image_non_parallel_zips_rgba
 );
 


### PR DESCRIPTION
The parallel RLE read benchmark is highly unreliable, showing variance from 20 to 28 without any changes to the code.

This PR adds a single-threaded equivalent of that benchmark so that performance could be more accurately measured.

I also suggest removing the parallel version to avoid confusion in the future, but that's up to you and not included in this PR.