### PR TITLE
Faster `differences_to_samples`

### DIFF
--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -409,8 +409,14 @@ mod optimize_bytes {
 
     /// Integrate over all differences to the previous value in order to reconstruct sample values.
     pub fn differences_to_samples(buffer: &mut [u8]){
-        for index in 1..buffer.len() {
-            buffer[index] = (buffer[index - 1] as i32 + buffer[index] as i32 - 128) as u8; // index unsafe but handled with care and unit-tested
+        let mut previous = buffer[0];
+        for chunk in &mut buffer[1..].chunks_exact_mut(2) {
+            let sample1 = (previous as i32 + chunk[0] as i32 - 128) as u8;
+            let diff2 = (chunk[0] as i32 + chunk[1] as i32 - 128) as u8;
+            let sample2 = (sample1 as i32 + diff2 as i32 - 128) as u8;
+            chunk[0] = sample1;
+            chunk[1] = sample2;
+            previous = sample2;
         }
     }
 

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -409,14 +409,15 @@ mod optimize_bytes {
 
     /// Integrate over all differences to the previous value in order to reconstruct sample values.
     pub fn differences_to_samples(buffer: &mut [u8]){
-        let mut previous = buffer[0];
+        let mut previous = buffer[0] as i16;
         for chunk in &mut buffer[1..].chunks_exact_mut(2) {
-            let sample1 = (previous as i32 + chunk[0] as i32 - 128) as u8;
-            let diff2 = (chunk[0] as i32 + chunk[1] as i32 - 128) as u8;
-            let sample2 = (sample1 as i32 + diff2 as i32 - 128) as u8;
-            chunk[0] = sample1;
-            chunk[1] = sample2;
-            previous = sample2;
+            let diff0 = chunk[0] as i16;
+            let diff1 = chunk[1] as i16;
+            let sample0 = (previous + diff0 - 128) as u8;
+            let sample1 = (previous + diff0 + diff1 - 256) as u8;
+            chunk[0] = sample0;
+            chunk[1] = sample1;
+            previous = sample1 as i16;
         }
     }
 

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -425,6 +425,8 @@ mod optimize_bytes {
                 // no bounds checks here due to indices and chunk size being constant
                 let diff0 = chunk[0] as i16;
                 let diff1 = chunk[1] as i16;
+                // these two computations do not depend on each other, unlike in the naive version,
+                // so they can be executed by the CPU in parallel via instruction-level parallelism
                 let sample0 = (previous + diff0 - 128) as u8;
                 let sample1 = (previous + diff0 + diff1 - 128 * 2) as u8;
                 chunk[0] = sample0;

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -444,8 +444,17 @@ mod optimize_bytes {
 
     /// Derive over all values in order to produce differences to the previous value.
     pub fn samples_to_differences(buffer: &mut [u8]){
-        for index in (1..buffer.len()).rev() {
-            buffer[index] = (buffer[index] as i32 - buffer[index - 1] as i32 + 128) as u8; // index unsafe but handled with care and unit-tested
+        // naive version:
+        // for index in (1..buffer.len()).rev() {
+        //     buffer[index] = (buffer[index] as i32 - buffer[index - 1] as i32 + 128) as u8;
+        // }
+
+        for i in (2..buffer.len()).rev().step_by(2) {
+            let (sample0, sample1, next_sample) = (buffer[i] as i32, buffer[i-1] as i32, buffer[i-2] as i32);
+            let diff0 = (sample0 - sample1 + 128) as u8;
+            let diff1 = (sample1 - next_sample + 128) as u8;
+            buffer[i] = diff0;
+            buffer[i-1] = diff1;
         }
     }
 

--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -477,7 +477,7 @@ mod optimize_bytes {
                 chunk[7] = (sample7 - sample6 + 128) as u8;
                 previous = sample7;
             }
-            // handle the remaining element at the end not processed by the loop over pairs, if present
+            // handle the remaining element at the end not processed by the loop over batches, if present
             for elem in &mut buffer[1..].chunks_exact_mut(8).into_remainder().iter_mut() {
                 let diff = (*elem as i16 - previous + 128) as u8;
                 previous = *elem as i16;


### PR DESCRIPTION
This function is responsible for 55% of execution time after #173; optimizations here have a large effect on performance.

This change leverages instruction-level parallelism to speed it up.

Benchmarks before (current master):
```
test read_single_image_non_parallel_zips_rgba        ... bench: 196,783,469 ns/iter (+/- 172,721)
test read_single_image_rle_all_channels              ... bench:  41,137,521 ns/iter (+/- 3,633,097)
test read_single_image_rle_non_parallel_all_channels ... bench:  98,932,909 ns/iter (+/- 2,856,674)
test read_single_image_uncompressed_from_buffer_rgba ... bench:  33,522,367 ns/iter (+/- 70,401)
test read_single_image_uncompressed_rgba             ... bench:  37,435,859 ns/iter (+/- 2,202,515)
test read_single_image_zips_rgba                     ... bench:  71,419,820 ns/iter (+/- 4,860,501)
```

Benchmarks after:

```
test read_single_image_non_parallel_zips_rgba        ... bench: 183,337,110 ns/iter (+/- 4,920,259)
test read_single_image_rle_all_channels              ... bench:  38,442,440 ns/iter (+/- 4,608,694)
test read_single_image_rle_non_parallel_all_channels ... bench:  81,506,752 ns/iter (+/- 796,542)
test read_single_image_uncompressed_from_buffer_rgba ... bench:  31,839,775 ns/iter (+/- 81,663)
test read_single_image_uncompressed_rgba             ... bench:  34,882,260 ns/iter (+/- 86,133)
test read_single_image_zips_rgba                     ... bench:  69,871,756 ns/iter (+/- 6,176,810)
```

The effect is more pronounced when combined with #173  (as in, this change makes up a larger percentage of execution time).

Tests pass, and they did fail on earlier versions where I messed them up slightly.

If this approach is OK with you, I can also try to optimize `samples_to_differences` in a similar fashion, although that's more difficult because it iterates in reverse and references future values instead of past values.