### PR TITLE
Reuse buffers in interleaving for a small speedup

### DIFF
--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -406,8 +406,6 @@ fn mod_p(x: i32, y: i32) -> i32 {
 
 /// A collection of functions used to prepare data for compression.
 mod optimize_bytes {
-    use crate::compression::SCRATCH_SPACE;
-
 
     /// Integrate over all differences to the previous value in order to reconstruct sample values.
     pub fn differences_to_samples(buffer: &mut [u8]) {
@@ -519,7 +517,7 @@ mod optimize_bytes {
         static SCRATCH_SPACE: Cell<Vec<u8>> = Cell::new(Vec::new());
     }
 
-    fn with_reused_buffer<F>(length: usize, func: F) where F: FnMut(&mut [u8]) {
+    fn with_reused_buffer<F>(length: usize, mut func: F) where F: FnMut(&mut [u8]) {
         SCRATCH_SPACE.with(|scratch_space| {
             // reuse a buffer if we've already initialized one
             let mut buffer = scratch_space.take();


### PR DESCRIPTION
Builds upon #173, please review and merge that first.

Allocating memory is cheap, but initializing it is not. This change makes the interleaving function reuse the buffers it has allocated and initialized. On RLE image decoding this further brings down the time spent in interleaving from 15% to 5%.