### PR TITLE
Use `zune-inflate` instead of `miniz_oxide` for decompression; it's faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/etemesi254/zune-image.git#3fd5558cf483f5c6b1455cbe9ab97fe92f2dd942"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bc976eac2cf2935926045b751d9bc7f1a268aa9ba0e11bef491dce239c7f26"
 dependencies = [
  "simd-adler32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "smallvec",
  "threadpool",
  "walkdir",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -474,6 +475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14a5df39617d7c8558154693a1bb8157a4aab8179209540cc0b10e5dc24e0b18"
+
+[[package]]
 name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,3 +622,11 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.0"
+source = "git+https://github.com/etemesi254/zune-image.git#3fd5558cf483f5c6b1455cbe9ab97fe92f2dd942"
+dependencies = [
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ miniz_oxide = "^0.6.2"         # zip compression for pxr24
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?
+zune-inflate = {git = "https://github.com/etemesi254/zune-image.git"}
 
 [dev-dependencies]
 image = { version = "0.24.3", default-features = false, features = ["png"] }         # used to convert one exr to some pngs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lebe = "^0.5.2"                # generic binary serialization
 half = "^2.1.0"                # 16 bit float pixel data type
 bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.6.2"         # zip compression for pxr24
-zune-inflate = "^0.2.0"        # zip decompression, faster than miniz_oxide
+zune-inflate = { version = "^0.2.0", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ lebe = "^0.5.2"                # generic binary serialization
 half = "^2.1.0"                # 16 bit float pixel data type
 bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.6.2"         # zip compression for pxr24
+zune-inflate = "^0.2.0"        # zip decompression, faster than miniz_oxide
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?
-zune-inflate = {git = "https://github.com/etemesi254/zune-image.git"}
 
 [dev-dependencies]
 image = { version = "0.24.3", default-features = false, features = ["png"] }         # used to convert one exr to some pngs

--- a/src/compression/pxr24.rs
+++ b/src/compression/pxr24.rs
@@ -145,7 +145,7 @@ pub fn decompress(channels: &ChannelList, bytes: ByteVec, area: IntegerBounds, e
         ))
     }
 
-    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size);
+    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size).set_size_hint(expected_byte_size);
     let mut decoder = zune_inflate::DeflateDecoder::new_with_options(&bytes, options);
     let raw = decoder.decode_zlib()
         .map_err(|_| Error::invalid("zlib-compressed data malformed"))?; // TODO share code with zip?

--- a/src/compression/pxr24.rs
+++ b/src/compression/pxr24.rs
@@ -145,8 +145,9 @@ pub fn decompress(channels: &ChannelList, bytes: ByteVec, area: IntegerBounds, e
         ))
     }
 
-    let raw = miniz_oxide::inflate
-        ::decompress_to_vec_zlib_with_limit(&bytes, expected_byte_size)
+    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size);
+    let mut decoder = zune_inflate::DeflateDecoder::new_with_options(&bytes, options);
+    let raw = decoder.decode_zlib()
         .map_err(|_| Error::invalid("zlib-compressed data malformed"))?; // TODO share code with zip?
 
     let mut read = raw.as_slice();

--- a/src/compression/zip.rs
+++ b/src/compression/zip.rs
@@ -19,7 +19,7 @@ pub fn decompress_bytes(
     expected_byte_size: usize,
     _pedantic: bool,
 ) -> Result<ByteVec> {
-    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size);
+    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size).set_size_hint(expected_byte_size);
     let mut decoder = zune_inflate::DeflateDecoder::new_with_options(&data, options);
     let mut decompressed = decoder.decode_zlib()
         .map_err(|_| Error::invalid("zlib-compressed data malformed"))?;

--- a/src/compression/zip.rs
+++ b/src/compression/zip.rs
@@ -19,8 +19,9 @@ pub fn decompress_bytes(
     expected_byte_size: usize,
     _pedantic: bool,
 ) -> Result<ByteVec> {
-    let mut decompressed = miniz_oxide::inflate
-    ::decompress_to_vec_zlib_with_limit(&data, expected_byte_size)
+    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size);
+    let mut decoder = zune_inflate::DeflateDecoder::new_with_options(&data, options);
+    let mut decompressed = decoder.decode_zlib()
         .map_err(|_| Error::invalid("zlib-compressed data malformed"))?;
 
     differences_to_samples(&mut decompressed);


### PR DESCRIPTION
[zune-inflate](https://crates.io/crates/zune-inflate) is a new DEFLATE/Zlib library in 100% safe Rust that's faster than `miniz_oxide` and even `zlib-ng`.

Features:
 - 100% safe Rust (like `miniz_oxide`)
 - Can decompress any data compressed by `miniz_oxide` and `zlib_ng`, verified by me with a fuzzer
 - Fuzzed for 1 billion (with a B) executions on random data, also by me, no hangs/panics/OOMs remaining
 - Very fast (beats even `zlib-ng`)

Drawbacks:
 - Slightly less precise tracking of output limits

Benchmark before:

```
test read_single_image_non_parallel_zips_rgba        ... bench: 196,783,469 ns/iter (+/- 172,721)
```

Benchmark after:

```
test read_single_image_non_parallel_zips_rgba        ... bench: 185,493,451 ns/iter (+/- 1,794,656)
```

Not a huge difference by itself, because a lot of time is spent in other things I'm optimizing, but it does add up. Profile: https://share.firefox.dev/3QloVgt

This profile clearly shows time spent in things touched by #173, #175 and not-yet-PR'd #178, in addition to inflate.

With all my optimization PRs combined this benchmark is down to:

```
test read_single_image_non_parallel_zips_rgba        ... bench: 129,482,284 ns/iter (+/- 200,734)
```