### PR TITLE
Implement size hints for `FlatSampleIterator`

### DIFF
--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -530,8 +530,14 @@ impl Iterator for FlatSampleIterator<'_> {
         }
         else { None }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.layer.channel_data.list.len() - self.channel_index;
+        (remaining, Some(remaining))
+    }
 }
 
+impl ExactSizeIterator for FlatSampleIterator<'_> {}
 
 impl<SampleData> AnyChannels<SampleData>{
 

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -531,8 +531,13 @@ impl Iterator for FlatSampleIterator<'_> {
         else { None }
     }
 
+    fn nth(&mut self, pos: usize) -> Option<Self::Item> {
+        self.channel_index += pos;
+        self.next()
+    }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.layer.channel_data.list.len() - self.channel_index;
+        let remaining = self.layer.channel_data.list.len().saturating_sub(self.channel_index);
         (remaining, Some(remaining))
     }
 }


### PR DESCRIPTION
This lets the caller know how much memory they should allocate.

Doesn't seem to do much to address #172, but may help some users since it's part of the public API.