### PR TITLE
Better read benchmarks

### DIFF
--- a/benches/read.rs
+++ b/benches/read.rs
@@ -83,6 +83,46 @@ fn read_single_image_rle_non_parallel_all_channels(bench: &mut Bencher) {
     })
 }
 
+/// Read with multi-core RLE decompression
+fn read_single_image_rle_rgba(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_rle.exr").unwrap();
+
+    bench.iter(||{
+        bencher::black_box(&mut file);
+
+        let image = exr::prelude::read()
+            .no_deep_data()
+            .largest_resolution_level()
+            .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
+            .all_layers()
+            .all_attributes()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
+/// Read without multi-core RLE decompression
+fn read_single_image_rle_non_parallel_rgba(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_rle.exr").unwrap();
+
+    bench.iter(||{
+        bencher::black_box(&mut file);
+
+        // copied from `read_all_flat_layers_from_file` and added `.non_parallel()`
+        let image = exr::prelude::read()
+            .no_deep_data()
+            .largest_resolution_level()
+            .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
+            .all_layers()
+            .all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
 /// Read with multi-core zip decompression
 fn read_single_image_zips_rgba(bench: &mut Bencher) {
     let mut file = fs::read("tests/images/valid/custom/crowskull/crow_zips.exr").unwrap();

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -141,7 +141,7 @@ fn read_single_image_zips_rgba(bench: &mut Bencher) {
 }
 
 /// Read without multi-core ZIP decompression
-fn read_single_image_non_parallel_zips_rgba(bench: &mut Bencher) {
+fn read_single_image_zips_non_parallel_rgba(bench: &mut Bencher) {
     let mut file = fs::read("tests/images/valid/custom/crowskull/crow_zips.exr").unwrap();
 
     bench.iter(||{
@@ -159,12 +159,14 @@ fn read_single_image_non_parallel_zips_rgba(bench: &mut Bencher) {
 }
 
 benchmark_group!(read,
-    read_single_image_uncompressed_non_parallel_rgba,
-    read_single_image_uncompressed_rgba,
-    read_single_image_zips_rgba,
     read_single_image_rle_all_channels,
     read_single_image_rle_non_parallel_all_channels,
-    read_single_image_non_parallel_zips_rgba
+    read_single_image_rle_non_parallel_rgba,
+    read_single_image_rle_rgba,
+    read_single_image_uncompressed_non_parallel_rgba,
+    read_single_image_uncompressed_rgba,
+    read_single_image_zips_non_parallel_rgba,
+    read_single_image_zips_rgba,
 );
 
 benchmark_main!(read);

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -10,26 +10,32 @@ use std::io::Cursor;
 use exr::image::pixel_vec::PixelVec;
 
 /// Read uncompressed (always single core)
-fn read_single_image_uncompressed_rgba(bench: &mut Bencher) {
+fn read_single_image_uncompressed_non_parallel_rgba(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
     bench.iter(||{
-        let path = "tests/images/valid/custom/crowskull/crow_uncompressed.exr";
+        bencher::black_box(&mut file);
 
-        let image = read_all_rgba_layers_from_file(
-            path, PixelVec::<(f16,f16,f16,f16)>::constructor, PixelVec::set_pixel
-        ).unwrap();
+        let image = exr::prelude::read()
+            .no_deep_data().largest_resolution_level()
+            .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
+            .all_layers().all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
 
         bencher::black_box(image);
     })
 }
 
 /// Read from in-memory in parallel
-fn read_single_image_uncompressed_from_buffer_rgba(bench: &mut Bencher) {
-    let file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
+fn read_single_image_uncompressed_rgba(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_uncompressed.exr").unwrap();
 
     bench.iter(||{
+        bencher::black_box(&mut file);
+
         let image = exr::prelude::read()
             .no_deep_data().largest_resolution_level()
-            .rgba_channels(PixelVec::<(f16,f16,f16,f16)>::constructor, PixelVec::set_pixel)
+            .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
             .all_layers().all_attributes()
             .from_buffered(Cursor::new(file.as_slice())).unwrap();
 
@@ -39,12 +45,34 @@ fn read_single_image_uncompressed_from_buffer_rgba(bench: &mut Bencher) {
 
 /// Read with multi-core zip decompression
 fn read_single_image_zips_rgba(bench: &mut Bencher) {
-    bench.iter(||{
-        let path = "tests/images/valid/custom/crowskull/crow_zips.exr";
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_zips.exr").unwrap();
 
-        let image = read_all_rgba_layers_from_file(
-            path, PixelVec::<(f16,f16,f16,f16)>::constructor, PixelVec::set_pixel
-        ).unwrap();
+    bench.iter(||{
+        bencher::black_box(&mut file);
+
+        let image = exr::prelude::read()
+            .no_deep_data().largest_resolution_level()
+            .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
+            .all_layers().all_attributes()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
+/// Read without multi-core ZIP decompression
+fn read_single_image_non_parallel_zips_rgba(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_zips.exr").unwrap();
+
+    bench.iter(||{
+        bencher::black_box(&mut file);
+
+        let image = exr::prelude::read()
+            .no_deep_data().largest_resolution_level()
+            .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
+            .all_layers().all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
 
         bencher::black_box(image);
     })
@@ -52,18 +80,30 @@ fn read_single_image_zips_rgba(bench: &mut Bencher) {
 
 /// Read with multi-core RLE decompression
 fn read_single_image_rle_all_channels(bench: &mut Bencher) {
-    bench.iter(||{
-        let path = "tests/images/valid/custom/crowskull/crow_rle.exr";
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_rle.exr").unwrap();
 
-        let image = read_all_flat_layers_from_file(path).unwrap();
+    bench.iter(||{
+        bencher::black_box(&mut file);
+
+        // copied from `read_all_flat_layers_from_file` and added `.non_parallel()`
+        let image = exr::prelude::read()
+            .no_deep_data()
+            .largest_resolution_level()
+            .all_channels()
+            .all_layers()
+            .all_attributes()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
         bencher::black_box(image);
     })
 }
 
 /// Read without multi-core RLE decompression
 fn read_single_image_rle_non_parallel_all_channels(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_rle.exr").unwrap();
+
     bench.iter(||{
-        let path = "tests/images/valid/custom/crowskull/crow_rle.exr";
+        bencher::black_box(&mut file);
 
         // copied from `read_all_flat_layers_from_file` and added `.non_parallel()`
         let image = exr::prelude::read()
@@ -73,30 +113,14 @@ fn read_single_image_rle_non_parallel_all_channels(bench: &mut Bencher) {
             .all_layers()
             .all_attributes()
             .non_parallel()
-            .from_file(path).unwrap();
-        bencher::black_box(image);
-    })
-}
-
-/// Read without multi-core ZIP decompression
-fn read_single_image_non_parallel_zips_rgba(bench: &mut Bencher) {
-    bench.iter(||{
-        let path = "tests/images/valid/custom/crowskull/crow_zips.exr";
-
-        let image = exr::prelude::read()
-            .no_deep_data().largest_resolution_level()
-            .rgba_channels(PixelVec::<(f16,f16,f16,f16)>::constructor, PixelVec::set_pixel)
-            .all_layers().all_attributes()
-            .non_parallel()
-            .from_file(path).unwrap();
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
 
         bencher::black_box(image);
     })
 }
-
 
 benchmark_group!(read,
-    read_single_image_uncompressed_from_buffer_rgba,
+    read_single_image_uncompressed_non_parallel_rgba,
     read_single_image_uncompressed_rgba,
     read_single_image_zips_rgba,
     read_single_image_rle_all_channels,

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -43,6 +43,46 @@ fn read_single_image_uncompressed_rgba(bench: &mut Bencher) {
     })
 }
 
+/// Read with multi-core RLE decompression
+fn read_single_image_rle_all_channels(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_rle.exr").unwrap();
+
+    bench.iter(||{
+        bencher::black_box(&mut file);
+
+        let image = exr::prelude::read()
+            .no_deep_data()
+            .largest_resolution_level()
+            .all_channels()
+            .all_layers()
+            .all_attributes()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
+/// Read without multi-core RLE decompression
+fn read_single_image_rle_non_parallel_all_channels(bench: &mut Bencher) {
+    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_rle.exr").unwrap();
+
+    bench.iter(||{
+        bencher::black_box(&mut file);
+
+        // copied from `read_all_flat_layers_from_file` and added `.non_parallel()`
+        let image = exr::prelude::read()
+            .no_deep_data()
+            .largest_resolution_level()
+            .all_channels()
+            .all_layers()
+            .all_attributes()
+            .non_parallel()
+            .from_buffered(Cursor::new(file.as_slice())).unwrap();
+
+        bencher::black_box(image);
+    })
+}
+
 /// Read with multi-core zip decompression
 fn read_single_image_zips_rgba(bench: &mut Bencher) {
     let mut file = fs::read("tests/images/valid/custom/crowskull/crow_zips.exr").unwrap();
@@ -71,47 +111,6 @@ fn read_single_image_non_parallel_zips_rgba(bench: &mut Bencher) {
             .no_deep_data().largest_resolution_level()
             .rgba_channels(PixelVec::<(f32,f32,f32,f32)>::constructor, PixelVec::set_pixel)
             .all_layers().all_attributes()
-            .non_parallel()
-            .from_buffered(Cursor::new(file.as_slice())).unwrap();
-
-        bencher::black_box(image);
-    })
-}
-
-/// Read with multi-core RLE decompression
-fn read_single_image_rle_all_channels(bench: &mut Bencher) {
-    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_rle.exr").unwrap();
-
-    bench.iter(||{
-        bencher::black_box(&mut file);
-
-        // copied from `read_all_flat_layers_from_file` and added `.non_parallel()`
-        let image = exr::prelude::read()
-            .no_deep_data()
-            .largest_resolution_level()
-            .all_channels()
-            .all_layers()
-            .all_attributes()
-            .from_buffered(Cursor::new(file.as_slice())).unwrap();
-
-        bencher::black_box(image);
-    })
-}
-
-/// Read without multi-core RLE decompression
-fn read_single_image_rle_non_parallel_all_channels(bench: &mut Bencher) {
-    let mut file = fs::read("tests/images/valid/custom/crowskull/crow_rle.exr").unwrap();
-
-    bench.iter(||{
-        bencher::black_box(&mut file);
-
-        // copied from `read_all_flat_layers_from_file` and added `.non_parallel()`
-        let image = exr::prelude::read()
-            .no_deep_data()
-            .largest_resolution_level()
-            .all_channels()
-            .all_layers()
-            .all_attributes()
             .non_parallel()
             .from_buffered(Cursor::new(file.as_slice())).unwrap();
 

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -159,14 +159,14 @@ fn read_single_image_zips_non_parallel_rgba(bench: &mut Bencher) {
 }
 
 benchmark_group!(read,
+    read_single_image_uncompressed_rgba,
+    read_single_image_uncompressed_non_parallel_rgba,
+    read_single_image_rle_rgba,
+    read_single_image_rle_non_parallel_rgba,
     read_single_image_rle_all_channels,
     read_single_image_rle_non_parallel_all_channels,
-    read_single_image_rle_non_parallel_rgba,
-    read_single_image_rle_rgba,
-    read_single_image_uncompressed_non_parallel_rgba,
-    read_single_image_uncompressed_rgba,
-    read_single_image_zips_non_parallel_rgba,
     read_single_image_zips_rgba,
+    read_single_image_zips_non_parallel_rgba,
 );
 
 benchmark_main!(read);


### PR DESCRIPTION
- Move reading from file into a buffer out of the benchmarking loop
- Use native `f32` instead of `f16` for benchmarking reads (conversion to `f16` is slow, which adds noise, and is profiled separately already)
- Add RLE RGBA benchmarks
- Ensure all benchmarks have a parallel and non-parallel version