### PR TITLE
Use zune-inflate for decompression, take 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,8 +625,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zune-inflate"
-version = "0.2.2"
-source = "git+https://github.com/etemesi254/zune-image.git#c797008451ec819fc4a01f878a81d8bdabf7ec39"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4172dc190e5202cdf12c889db7fa2d4b9323caca5a6ae3f8ba6e69cef10f86"
 dependencies = [
  "simd-adler32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,9 +625,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zune-inflate"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0bc976eac2cf2935926045b751d9bc7f1a268aa9ba0e11bef491dce239c7f26"
+version = "0.2.2"
+source = "git+https://github.com/etemesi254/zune-image.git#b1444e6b515850b809e860722a226a1b51a7a28e"
 dependencies = [
  "simd-adler32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/etemesi254/zune-image.git#3fd5558cf483f5c6b1455cbe9ab97fe92f2dd942"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bc976eac2cf2935926045b751d9bc7f1a268aa9ba0e11bef491dce239c7f26"
 dependencies = [
  "simd-adler32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,8 +625,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zune-inflate"
-version = "0.2.2"
-source = "git+https://github.com/etemesi254/zune-image.git#b1444e6b515850b809e860722a226a1b51a7a28e"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e9ed9c3f1a2abe1cd3a9ea252d62b91ad1efc31b55a0e4fb702164caf56402"
 dependencies = [
  "simd-adler32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,9 +625,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zune-inflate"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e9ed9c3f1a2abe1cd3a9ea252d62b91ad1efc31b55a0e4fb702164caf56402"
+version = "0.2.2"
+source = "git+https://github.com/etemesi254/zune-image.git#c797008451ec819fc4a01f878a81d8bdabf7ec39"
 dependencies = [
  "simd-adler32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "smallvec",
  "threadpool",
  "walkdir",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -474,6 +475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14a5df39617d7c8558154693a1bb8157a4aab8179209540cc0b10e5dc24e0b18"
+
+[[package]]
 name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,3 +622,11 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.0"
+source = "git+https://github.com/etemesi254/zune-image.git#3fd5558cf483f5c6b1455cbe9ab97fe92f2dd942"
+dependencies = [
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lebe = "^0.5.2"                # generic binary serialization
 half = "^2.1.0"                # 16 bit float pixel data type
 bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.6.2"         # zip compression for pxr24
-zune-inflate = { version = "^0.2.0", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
+zune-inflate = { version = "^0.2.2", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ miniz_oxide = "^0.6.2"         # zip compression for pxr24
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?
+zune-inflate = {git = "https://github.com/etemesi254/zune-image.git"}
 
 [dev-dependencies]
 image = { version = "0.24.3", default-features = false, features = ["png"] }         # used to convert one exr to some pngs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lebe = "^0.5.2"                # generic binary serialization
 half = "^2.1.0"                # 16 bit float pixel data type
 bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.6.2"         # zip compression for pxr24
-zune-inflate = "^0.2.0"        # zip decompression, faster than miniz_oxide
+zune-inflate = { version = "^0.2.0", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lebe = "^0.5.2"                # generic binary serialization
 half = "^2.1.0"                # 16 bit float pixel data type
 bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.6.2"         # zip compression for pxr24
-zune-inflate = { git = "https://github.com/etemesi254/zune-image.git", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
+zune-inflate = { version = "^0.2.3", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ lebe = "^0.5.2"                # generic binary serialization
 half = "^2.1.0"                # 16 bit float pixel data type
 bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.6.2"         # zip compression for pxr24
+zune-inflate = "^0.2.0"        # zip decompression, faster than miniz_oxide
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?
-zune-inflate = {git = "https://github.com/etemesi254/zune-image.git"}
 
 [dev-dependencies]
 image = { version = "0.24.3", default-features = false, features = ["png"] }         # used to convert one exr to some pngs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lebe = "^0.5.2"                # generic binary serialization
 half = "^2.1.0"                # 16 bit float pixel data type
 bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.6.2"         # zip compression for pxr24
-zune-inflate = { version = "=0.2.1", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
+zune-inflate = { git = "https://github.com/etemesi254/zune-image.git", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lebe = "^0.5.2"                # generic binary serialization
 half = "^2.1.0"                # 16 bit float pixel data type
 bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.6.2"         # zip compression for pxr24
-zune-inflate = { version = "^0.2.2", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
+zune-inflate = { version = "=0.2.1", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 threadpool = "^1.8.1"          # threading for parallel compression     TODO make this an optional feature?
 flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?

--- a/src/compression/pxr24.rs
+++ b/src/compression/pxr24.rs
@@ -145,7 +145,7 @@ pub fn decompress(channels: &ChannelList, bytes: ByteVec, area: IntegerBounds, e
         ))
     }
 
-    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size);
+    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size).set_size_hint(expected_byte_size);
     let mut decoder = zune_inflate::DeflateDecoder::new_with_options(&bytes, options);
     let raw = decoder.decode_zlib()
         .map_err(|_| Error::invalid("zlib-compressed data malformed"))?; // TODO share code with zip?

--- a/src/compression/pxr24.rs
+++ b/src/compression/pxr24.rs
@@ -145,8 +145,9 @@ pub fn decompress(channels: &ChannelList, bytes: ByteVec, area: IntegerBounds, e
         ))
     }
 
-    let raw = miniz_oxide::inflate
-        ::decompress_to_vec_zlib_with_limit(&bytes, expected_byte_size)
+    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size);
+    let mut decoder = zune_inflate::DeflateDecoder::new_with_options(&bytes, options);
+    let raw = decoder.decode_zlib()
         .map_err(|_| Error::invalid("zlib-compressed data malformed"))?; // TODO share code with zip?
 
     let mut read = raw.as_slice();

--- a/src/compression/zip.rs
+++ b/src/compression/zip.rs
@@ -19,7 +19,7 @@ pub fn decompress_bytes(
     expected_byte_size: usize,
     _pedantic: bool,
 ) -> Result<ByteVec> {
-    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size);
+    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size).set_size_hint(expected_byte_size);
     let mut decoder = zune_inflate::DeflateDecoder::new_with_options(&data, options);
     let mut decompressed = decoder.decode_zlib()
         .map_err(|_| Error::invalid("zlib-compressed data malformed"))?;

--- a/src/compression/zip.rs
+++ b/src/compression/zip.rs
@@ -19,8 +19,9 @@ pub fn decompress_bytes(
     expected_byte_size: usize,
     _pedantic: bool,
 ) -> Result<ByteVec> {
-    let mut decompressed = miniz_oxide::inflate
-    ::decompress_to_vec_zlib_with_limit(&data, expected_byte_size)
+    let options = zune_inflate::DeflateOptions::default().set_limit(expected_byte_size);
+    let mut decoder = zune_inflate::DeflateDecoder::new_with_options(&data, options);
+    let mut decompressed = decoder.decode_zlib()
         .map_err(|_| Error::invalid("zlib-compressed data malformed"))?;
 
     differences_to_samples(&mut decompressed);


### PR DESCRIPTION
Another stab at #179 now that zune-inflate is fuzzed and roundtrip-fuzzed on CI.

Before:
```
test read_single_image_zips_non_parallel_rgba         ... bench: 121,828,074 ns/iter (+/- 130,167)
```

After:

```
test read_single_image_zips_non_parallel_rgba         ... bench: 113,364,196 ns/iter (+/- 93,985)
```

No effect on the parallel version - apparently the main thread is the bottleneck.