### PR TITLE
Less backpressure

### DIFF
--- a/src/block/reader.rs
+++ b/src/block/reader.rs
@@ -413,7 +413,9 @@ impl<R: ChunksReader> ParallelBlockDecompressor<R> {
             return Err(chunks);
         }
 
-        let max_threads = pool.max_count().max(1).min(chunks.len()) + 2; // ca one block for each thread at all times
+        // Have up to twice as many sent for decoding at the same time as there are threads.
+        // This ensures that at no point a worker thread is blocked waiting for more work to be sent
+        let max_threads = (pool.max_count().max(1) * 2).min(chunks.len());
 
         let (send, recv) = flume::unbounded(); // TODO bounded channel simplifies logic?
         Ok(Self {


### PR DESCRIPTION
Queue up to `num_threads * 2` chunks for decompression instead of `num_threads + 2`. Lets the decoder build up a bigger backlog to make parallel decoding less sensitive to thread scheduling.

This comes at the cost of increasing the peak memory usage by `num_threads * compressed_chunk_size`.

Also correctly cap the number at the number of chunks to decode.

Improves a benchmark from #181:

Before:

```
test read_single_image_zips_rgba                      ... bench:  44,334,850 ns/iter (+/- 6,742,086)
```

After:

```
test read_single_image_zips_rgba                      ... bench:  41,789,371 ns/iter (+/- 6,471,339)
```