### PR TITLE
Change `convert_current_to_little_endian` to return `Cow<[u8]>`

### DIFF
--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -129,7 +129,7 @@ impl UncompressedBlock {
             CompressedBlock::Tile(CompressedTileBlock { compressed_pixels, .. }) |
             CompressedBlock::ScanLine(CompressedScanLineBlock { compressed_pixels, .. }) => {
                 Ok(UncompressedBlock {
-                    data: header.compression.decompress_image_section(header, compressed_pixels, absolute_indices, pedantic)?,
+                    data: header.compression.decompress_image_section(header, &compressed_pixels, absolute_indices, pedantic)?,
                     index: BlockIndex {
                         layer: chunk.layer_index,
                         pixel_position: absolute_indices.position.to_usize("data indices start")?,
@@ -170,7 +170,7 @@ impl UncompressedBlock {
         if !header.compression.may_loose_data() { debug_assert_eq!(
             &header.compression.decompress_image_section(
                 header,
-                header.compression.compress_image_section(header, data.clone(), absolute_indices)?,
+                &header.compression.compress_image_section(header, data.clone(), absolute_indices)?,
                 absolute_indices,
                 true
             ).unwrap(),

--- a/src/compression/b44/mod.rs
+++ b/src/compression/b44/mod.rs
@@ -258,7 +258,7 @@ fn cpy_u8(src: &[u16], src_i: usize, dst: &mut [u8], dst_i: usize, n: usize) {
 
 pub fn decompress(
     channels: &ChannelList,
-    compressed: ByteVec,
+    compressed: Bytes,
     rectangle: IntegerBounds,
     expected_byte_size: usize,
     _pedantic: bool,
@@ -496,7 +496,7 @@ pub fn compress(
     // TODO do not convert endianness for f16-only images
     //      see https://github.com/AcademySoftwareFoundation/openexr/blob/3bd93f85bcb74c77255f28cdbb913fdbfbb39dfe/OpenEXR/IlmImf/ImfTiledOutputFile.cpp#L750-L842
     let uncompressed = super::convert_current_to_little_endian(uncompressed, channels, rectangle);
-    let uncompressed = uncompressed.as_slice(); // TODO no alloc
+    let uncompressed = &*uncompressed; 
 
     let mut channel_data = Vec::new();
 
@@ -722,7 +722,7 @@ mod test {
         let compressed = b44::compress(&channels, &pixel_bytes, rectangle, true).unwrap();
 
         let decompressed =
-            b44::decompress(&channels, compressed.clone(), rectangle, pixel_bytes.len(), true).unwrap();
+            b44::decompress(&channels, &compressed, rectangle, pixel_bytes.len(), true).unwrap();
 
         assert_eq!(decompressed.len(), pixel_bytes.len());
 

--- a/src/compression/pxr24.rs
+++ b/src/compression/pxr24.rs
@@ -51,7 +51,7 @@ pub fn compress(channels: &ChannelList, remaining_bytes: Bytes<'_>, area: Intege
 
     // see https://github.com/AcademySoftwareFoundation/openexr/blob/3bd93f85bcb74c77255f28cdbb913fdbfbb39dfe/OpenEXR/IlmImf/ImfTiledOutputFile.cpp#L750-L842
     let remaining_bytes = super::convert_current_to_little_endian(remaining_bytes, channels, area);
-    let mut remaining_bytes = remaining_bytes.as_slice(); // TODO less allocation
+    let mut remaining_bytes = &*remaining_bytes;
 
     let bytes_per_pixel: usize = channels.list.iter()
         .map(|channel| match channel.sample_type {
@@ -138,7 +138,7 @@ pub fn compress(channels: &ChannelList, remaining_bytes: Bytes<'_>, area: Intege
 }
 
 #[cfg_attr(target_endian = "big", allow(unused, unreachable_code))]
-pub fn decompress(channels: &ChannelList, bytes: ByteVec, area: IntegerBounds, expected_byte_size: usize, pedantic: bool) -> Result<ByteVec> {
+pub fn decompress(channels: &ChannelList, bytes: Bytes, area: IntegerBounds, expected_byte_size: usize, pedantic: bool) -> Result<ByteVec> {
     #[cfg(target_endian = "big")] {
         return Err(Error::unsupported(
             "PXR24 decompression method not supported yet on big endian processor architecture"

--- a/src/compression/rle.rs
+++ b/src/compression/rle.rs
@@ -11,12 +11,12 @@ const MAX_RUN_LENGTH : usize = 127;
 
 pub fn decompress_bytes(
     channels: &ChannelList,
-    compressed: ByteVec,
+    compressed: Bytes,
     rectangle: IntegerBounds,
     expected_byte_size: usize,
     pedantic: bool,
 ) -> Result<ByteVec> {
-    let mut remaining = compressed.as_slice();
+    let mut remaining = compressed;
     let mut decompressed = Vec::with_capacity(expected_byte_size.min(8*2048));
 
     while !remaining.is_empty() && decompressed.len() != expected_byte_size {
@@ -45,7 +45,7 @@ pub fn decompress_bytes(
 
 pub fn compress_bytes(channels: &ChannelList, uncompressed: Bytes<'_>, rectangle: IntegerBounds) -> Result<ByteVec> {
     // see https://github.com/AcademySoftwareFoundation/openexr/blob/3bd93f85bcb74c77255f28cdbb913fdbfbb39dfe/OpenEXR/IlmImf/ImfTiledOutputFile.cpp#L750-L842
-    let mut data = super::convert_current_to_little_endian(uncompressed, channels, rectangle);// TODO no alloc
+    let mut data = super::convert_current_to_little_endian(uncompressed, channels, rectangle).into_owned();// TODO no alloc
 
     separate_bytes_fragments(&mut data);
     samples_to_differences(&mut data);

--- a/src/compression/zip.rs
+++ b/src/compression/zip.rs
@@ -14,13 +14,13 @@ use crate::error::Result;
 
 pub fn decompress_bytes(
     channels: &ChannelList,
-    data: ByteVec,
+    data: Bytes,
     rectangle: IntegerBounds,
     expected_byte_size: usize,
     _pedantic: bool,
 ) -> Result<ByteVec> {
     let mut decompressed = miniz_oxide::inflate
-    ::decompress_to_vec_zlib_with_limit(&data, expected_byte_size)
+    ::decompress_to_vec_zlib_with_limit(data, expected_byte_size)
         .map_err(|_| Error::invalid("zlib-compressed data malformed"))?;
 
     differences_to_samples(&mut decompressed);
@@ -31,7 +31,7 @@ pub fn decompress_bytes(
 
 pub fn compress_bytes(channels: &ChannelList, uncompressed: Bytes<'_>, rectangle: IntegerBounds) -> Result<ByteVec> {
     // see https://github.com/AcademySoftwareFoundation/openexr/blob/3bd93f85bcb74c77255f28cdbb913fdbfbb39dfe/OpenEXR/IlmImf/ImfTiledOutputFile.cpp#L750-L842
-    let mut packed = convert_current_to_little_endian(uncompressed, channels, rectangle);
+    let mut packed = convert_current_to_little_endian(uncompressed, channels, rectangle).into_owned();
 
     separate_bytes_fragments(&mut packed);
     samples_to_differences(&mut packed);


### PR DESCRIPTION
This was a pretty easy change to make. I haven't profiled it but according to heaptrack, this reduces the number of allocations in a benchmark by half:

![20230120_19h30m26s_grim](https://user-images.githubusercontent.com/13566135/213793533-98ec19d0-3df0-4401-bccb-b12a7a754ce7.png)
![20230120_20h50m04s_grim](https://user-images.githubusercontent.com/13566135/213793527-e74d82ed-7b33-4355-a67e-0bc2d079808a.png)

