### PR TITLE
Don't use flume's default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.7.1"         # zip compression for pxr24
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 rayon-core = "^1.11.0"         # threading for parallel compression     TODO make this an optional feature?
-flume = "^0.10.9"              # crossbeam, but less unsafe code        TODO make this an optional feature?
+flume = { version = "^0.10.9", default-features = false }              # crossbeam, but less unsafe code        TODO make this an optional feature?
 zune-inflate = { version = "^0.2.3", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 
 [dev-dependencies]


### PR DESCRIPTION
Notably, this eliminates a dependency on `syn` which improves compile time.