### PR TITLE
bump flume version for spin-rs dependency update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.7.1"         # zip compression for pxr24
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 rayon-core = "^1.11.0"         # threading for parallel compression     TODO make this an optional feature?
-flume = { version = "^0.10.9", default-features = false }              # crossbeam, but less unsafe code        TODO make this an optional feature?
+flume = { version = "^0.11.0", default-features = false }              # crossbeam, but less unsafe code        TODO make this an optional feature?
 zune-inflate = { version = "^0.2.3", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/johannesvollmer/exrs"
 readme = "README.md"
 license = "BSD-3-Clause"
 exclude = [ "specification/*", "specification/**", "tests/images/*", "tests/images/**" ]
-rust-version = "1.59.0"
+rust-version = "1.61.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
flume depends on spin-rs, and spin-rs prior to `v0.9.8` has a [concurrency bug](https://github.com/advisories/GHSA-2qv5-7mw5-j3cg)

flume updated its spin dependency in https://github.com/zesterer/flume/commit/9f67d0d2b4c57844f3b5d6ec26e6d9f4446dae93 and released that as `v0.11.0` in https://github.com/zesterer/flume/commit/ee6fe6adb98856edbda47d1cc867cbc255ff0d88
