### PR TITLE
Use checked_sub/checked_div in meta/header.rs

### DIFF
--- a/src/meta/header.rs
+++ b/src/meta/header.rs
@@ -533,7 +533,9 @@ impl Header {
 
             CompressedBlock::ScanLine(ref block) => {
                 let size = self.compression.scan_lines_per_block() as i32;
-                let y = (block.y_coordinate - self.own_attributes.layer_position.y()) / size;
+
+                let diff = block.y_coordinate.checked_sub(self.own_attributes.layer_position.y()).ok_or(Error::invalid("invalid header"))?;
+                let y = diff.checked_div(size).ok_or(Error::invalid("invalid header"))?;
 
                 if y < 0 {
                     return Err(Error::invalid("scan block y coordinate"));
@@ -552,7 +554,9 @@ impl Header {
     /// Computes the absolute tile coordinate data indices, which start at `0`.
     pub fn get_scan_line_block_tile_coordinates(&self, block_y_coordinate: i32) -> Result<TileCoordinates> {
         let size = self.compression.scan_lines_per_block() as i32;
-        let y = (block_y_coordinate - self.own_attributes.layer_position.1) / size;
+
+        let diff = block_y_coordinate.checked_sub(self.own_attributes.layer_position.1).ok_or(Error::invalid("invalid header"))?;
+        let y = diff.checked_div(size).ok_or(Error::invalid("invalid header"))?;
 
         if y < 0 {
             return Err(Error::invalid("scan block y coordinate"));


### PR DESCRIPTION
While I was fuzzing [image-rs/fuzz/fuzzer_script_exr.rs](https://github.com/image-rs/image/blob/master/fuzz/fuzzers/fuzzer_script_exr.rs), I found `an attempt to subtract with overflow` error in [meta/header.rs](https://github.com/johannesvollmer/exrs/blob/master/src/meta/header.rs#L536)

```
$ ./image /home/toka/LibAFL/crash-47a56cc2953de83d.exr 
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 3118772312
INFO: Loaded 1 modules   (571009 inline 8-bit counters): 571009 [0x56459b9db730, 0x56459ba66db1), 
INFO: Loaded 1 PC tables (571009 PCs): 571009 [0x56459ba66db8,0x56459c31d5c8), 
./image: Running 1 inputs 1 time(s) each.
Running: /home/toka/LibAFL/crash-47a56cc2953de83d.exr
thread 'OpenEXR Block Decompressor Thread #0' panicked at /home/toka/crabsandwich/image-rs/exrs/src/meta/header.rs:536:25:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
==175008== ERROR: libFuzzer: deadly signal
thread 'OpenEXR Block Decompressor Thread #4' panicked at /home/toka/crabsandwich/image-rs/exrs/src/meta/header.rs:536:25:
attempt to subtract with overflow
Aborted (core dumped)
```

This PR will use checked_sub/checked_div to prevent panics