### PR TITLE
Use loole to improve channel performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.7.1"         # zip compression for pxr24
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 rayon-core = "^1.11.0"         # threading for parallel compression     TODO make this an optional feature?
-loole = "0.1.13"
+loole = "0.1.14"
 zune-inflate = { version = "^0.2.3", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.7.1"         # zip compression for pxr24
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 rayon-core = "^1.11.0"         # threading for parallel compression     TODO make this an optional feature?
-loole = "0.1.14"
+loole = "0.1.15"
 zune-inflate = { version = "^0.2.3", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.7.1"         # zip compression for pxr24
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 rayon-core = "^1.11.0"         # threading for parallel compression     TODO make this an optional feature?
-flume = { version = "^0.11.0", default-features = false }              # crossbeam, but less unsafe code        TODO make this an optional feature?
+loole = "0.1.13"
 zune-inflate = { version = "^0.2.3", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 
 [dev-dependencies]

--- a/src/block/reader.rs
+++ b/src/block/reader.rs
@@ -387,8 +387,8 @@ impl<R: ChunksReader> SequentialBlockDecompressor<R> {
 #[derive(Debug)]
 pub struct ParallelBlockDecompressor<R: ChunksReader> {
     remaining_chunks: R,
-    sender: flume::Sender<Result<UncompressedBlock>>,
-    receiver: flume::Receiver<Result<UncompressedBlock>>,
+    sender: loole::Sender<Result<UncompressedBlock>>,
+    receiver: loole::Receiver<Result<UncompressedBlock>>,
     currently_decompressing_count: usize,
     max_threads: usize,
 
@@ -437,7 +437,7 @@ impl<R: ChunksReader> ParallelBlockDecompressor<R> {
 
         let max_threads = pool.current_num_threads().max(1).min(chunks.len()) + 2; // ca one block for each thread at all times
 
-        let (send, recv) = flume::unbounded(); // TODO bounded channel simplifies logic?
+        let (send, recv) = loole::unbounded(); // TODO bounded channel simplifies logic?
 
         Ok(Self {
             shared_meta_data_ref: Arc::new(chunks.meta_data().clone()),

--- a/src/block/writer.rs
+++ b/src/block/writer.rs
@@ -337,8 +337,8 @@ pub struct ParallelBlocksCompressor<'w, W> {
     meta: &'w MetaData,
     sorted_writer: SortedBlocksWriter<'w, W>,
 
-    sender: flume::Sender<Result<(usize, usize, Chunk)>>,
-    receiver: flume::Receiver<Result<(usize, usize, Chunk)>>,
+    sender: loole::Sender<Result<(usize, usize, Chunk)>>,
+    receiver: loole::Receiver<Result<(usize, usize, Chunk)>>,
     pool: rayon_core::ThreadPool,
 
     currently_compressing_count: usize,
@@ -379,7 +379,7 @@ impl<'w, W> ParallelBlocksCompressor<'w, W> where W: 'w + ChunksWriter {
         };
 
         let max_threads = pool.current_num_threads().max(1).min(chunks_writer.total_chunks_count()) + 2; // ca one block for each thread at all times
-        let (send, recv) = flume::unbounded(); // TODO bounded channel simplifies logic?
+        let (send, recv) = loole::unbounded(); // TODO bounded channel simplifies logic?
 
         Some(Self {
             sorted_writer: SortedBlocksWriter::new(meta, chunks_writer),


### PR DESCRIPTION
Hello, this pull request replaces Flume with Loole, my recent safe implementation of MPMC channel that has successfully passed all Flume tests for all implemented APIs. Consequently, both channel-related benchmarks in read.rs have demonstrated the following improvements:

```yaml
# Using flume
test read_single_image_rle_all_channels               ... bench:  14,087,088 ns/iter (+/- 1,028,918)
test read_single_image_rle_non_parallel_all_channels  ... bench:  22,124,520 ns/iter (+/- 148,387)

# Using loole
test read_single_image_rle_all_channels               ... bench:   7,956,153 ns/iter (+/- 748,611)
test read_single_image_rle_non_parallel_all_channels  ... bench:  16,360,325 ns/iter (+/- 77,868)
```

Loole's GitHub: [https://github.com/mahdi-shojaee/loole](https://github.com/mahdi-shojaee/loole)

Thanks