### PR TITLE
Drop flume to reduce dependency footprint now that std has a good channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ bit_field = "^0.10.1"          # exr file version bit flags
 miniz_oxide = "^0.7.1"         # zip compression for pxr24
 smallvec = "^1.7.0"            # make cache-friendly allocations        TODO profile if smallvec is really an improvement!
 rayon-core = "^1.11.0"         # threading for parallel compression     TODO make this an optional feature?
-flume = { version = "^0.11.0", default-features = false }              # crossbeam, but less unsafe code        TODO make this an optional feature?
 zune-inflate = { version = "^0.2.3", default-features = false, features = ["zlib"] }  # zip decompression, faster than miniz_oxide
 
 [dev-dependencies]

--- a/src/block/writer.rs
+++ b/src/block/writer.rs
@@ -5,12 +5,13 @@ use std::fmt::Debug;
 use std::io::Seek;
 use std::iter::Peekable;
 use std::ops::Not;
+use std::sync::mpsc;
 use rayon_core::{ThreadPool, ThreadPoolBuildError};
 
 use smallvec::alloc::collections::BTreeMap;
 
 use crate::block::UncompressedBlock;
-use crate::block::chunk::{Chunk};
+use crate::block::chunk::Chunk;
 use crate::compression::Compression;
 use crate::error::{Error, Result, UnitResult, usize_to_u64};
 use crate::io::{Data, Tracking, Write};
@@ -337,8 +338,8 @@ pub struct ParallelBlocksCompressor<'w, W> {
     meta: &'w MetaData,
     sorted_writer: SortedBlocksWriter<'w, W>,
 
-    sender: flume::Sender<Result<(usize, usize, Chunk)>>,
-    receiver: flume::Receiver<Result<(usize, usize, Chunk)>>,
+    sender: mpsc::Sender<Result<(usize, usize, Chunk)>>,
+    receiver: mpsc::Receiver<Result<(usize, usize, Chunk)>>,
     pool: rayon_core::ThreadPool,
 
     currently_compressing_count: usize,
@@ -379,7 +380,7 @@ impl<'w, W> ParallelBlocksCompressor<'w, W> where W: 'w + ChunksWriter {
         };
 
         let max_threads = pool.current_num_threads().max(1).min(chunks_writer.total_chunks_count()) + 2; // ca one block for each thread at all times
-        let (send, recv) = flume::unbounded(); // TODO bounded channel simplifies logic?
+        let (send, recv) = mpsc::channel(); // TODO bounded channel simplifies logic?
 
         Some(Self {
             sorted_writer: SortedBlocksWriter::new(meta, chunks_writer),


### PR DESCRIPTION
Two years ago the standard library's channel implementation was [switched](https://github.com/rust-lang/rust/pull/93563) to a variant of crossbeam-channel. Now that std ships a good channel implementation, there is no reason to pull in a third-party one.

This removes a lot of dependency bloat from the `image` crate:

```
│   ├── flume v0.10.9
│   │   ├── futures-core v0.3.0
│   │   ├── futures-sink v0.3.0
│   │   ├── nanorand v0.6.0
│   │   │   └── getrandom v0.2.3
│   │   │       ├── cfg-if v1.0.0
│   │   │       └── libc v0.2.133
│   │   ├── pin-project v1.0.2
│   │   │   └── pin-project-internal v1.0.2 (proc-macro)
│   │   │       ├── proc-macro2 v1.0.52
│   │   │       │   └── unicode-ident v1.0.0
│   │   │       ├── quote v1.0.26
│   │   │       │   └── proc-macro2 v1.0.52 (*)
│   │   │       └── syn v1.0.67
│   │   │           ├── proc-macro2 v1.0.52 (*)
│   │   │           ├── quote v1.0.26 (*)
│   │   │           └── unicode-xid v0.2.0
│   │   └── spin v0.9.2
│   │       └── lock_api v0.4.0
│   │           └── scopeguard v1.1.0
```

All the fields with channels in them are private, so this is semver-compatible.

This change has no effect on benchmarks on my 6-core desktop CPU.