### PR TITLE
add new byte attribute and new compression method

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,12 @@ pub(crate) fn i32_to_usize(value: i32, error_message: &'static str) -> Result<us
     usize::try_from(value).map_err(|_| Error::invalid(error_message))
 }
 
+/// Return error on overflow.
+#[inline]
+pub(crate) fn usize_to_u32(value: usize, error_message: &'static str) -> Result<u32> {
+    u32::try_from(value).map_err(|_| Error::invalid(error_message))
+}
+
 /// Return error on invalid range.
 #[inline]
 pub(crate) fn usize_to_u16(value: usize) -> Result<u16> {
@@ -123,6 +129,7 @@ pub(crate) fn u32_to_usize(value: u32) -> usize {
     usize::try_from(value).expect("(u32 as usize) overflowed")
 }
 
+// TODO make all errors, no panics.
 /// Panic on overflow.
 #[inline]
 pub(crate) fn usize_to_i32(value: usize) -> i32 {

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,7 +13,7 @@ use std::io::{Seek, SeekFrom};
 use std::path::Path;
 use std::fs::File;
 use std::convert::TryFrom;
-
+use smallvec::{Array, SmallVec};
 
 /// Skip reading uninteresting bytes without allocating.
 #[inline]
@@ -282,10 +282,18 @@ pub trait Data: Sized + Default + Clone {
     ///
     /// This method will not allocate more memory than `soft_max` at once.
     /// If `hard_max` is specified, it will never read any more than that.
-    /// Returns `Error::Invalid` if reader does not contain the desired number of elements.
+    /// Returns `Error::Invalid` if the reader does not contain the desired number of elements.
     /// Reads from little-endian byte source.
     #[inline]
-    fn read_vec_le(read: &mut impl Read, data_size: usize, soft_max: usize, hard_max: Option<usize>, purpose: &'static str) -> Result<Vec<Self>> {
+    fn read_vec_le(read: &mut impl Read, data_size: usize, soft_max: usize, hard_max: Option<usize>, purpose: &'static str)
+        -> Result<Vec<Self>>
+    {
+        if let Some(max) = hard_max {
+            if data_size > max {
+                return Err(Error::invalid(purpose))
+            }
+        }
+
         let mut vec = Vec::with_capacity(data_size.min(soft_max));
         Self::read_into_vec_le(read, &mut vec, data_size, soft_max, hard_max, purpose)?;
         Ok(vec)
@@ -310,7 +318,12 @@ pub trait Data: Sized + Default + Clone {
     /// If `hard_max` is specified, it will never read any more than that.
     /// Returns `Error::Invalid` if reader does not contain the desired number of elements.
     #[inline]
-    fn read_into_vec_le(read: &mut impl Read, data: &mut Vec<Self>, data_size: usize, soft_max: usize, hard_max: Option<usize>, purpose: &'static str) -> UnitResult {
+    fn read_into_vec_le(
+        read: &mut impl Read,
+        data: &mut impl ResizableVec<Self>,
+        data_size: usize, soft_max: usize, hard_max: Option<usize>,
+        purpose: &'static str
+    ) -> UnitResult {
         if let Some(max) = hard_max {
             if data_size > max {
                 return Err(Error::invalid(purpose))
@@ -327,7 +340,7 @@ pub trait Data: Sized + Default + Clone {
             let chunk_end = (chunk_start + soft_max).min(data_size);
 
             data.resize(chunk_end, Self::default());
-            Self::read_slice_le(read, &mut data[chunk_start .. chunk_end])?; // safe because of `min(data_size)``
+            Self::read_slice_le(read, &mut data.as_mut()[chunk_start .. chunk_end])?; // safe because of `min(data_size)`
         }
 
         Ok(())
@@ -360,6 +373,32 @@ pub trait Data: Sized + Default + Clone {
         }
     }
 }
+
+/// A unifying trait that is implemented for Vec and SmallVec,
+/// focused on resizing capabilities.
+pub trait ResizableVec<T>: AsMut<[T]> {
+    fn resize(&mut self, new_len: usize, value: T);
+    fn len(&self) -> usize;
+}
+
+impl<T: Clone> ResizableVec<T> for Vec<T> {
+    fn resize(&mut self, new_len: usize, value: T) {
+        Vec::resize(self, new_len, value)
+    }
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+}
+
+impl<T: Clone, A: Array<Item=T>> ResizableVec<T> for SmallVec<A> {
+    fn resize(&mut self, new_len: usize, value: T) {
+        SmallVec::resize(self, new_len, value)
+    }
+    fn len(&self) -> usize {
+        SmallVec::len(self)
+    }
+}
+
 
 
 macro_rules! implement_data_for_primitive {

--- a/src/meta/attribute.rs
+++ b/src/meta/attribute.rs
@@ -82,6 +82,20 @@ pub enum AttributeValue {
     /// 3D float vector.
     FloatVec3((f32, f32, f32)),
 
+    /// An explicitly untyped attribute for binary application data.
+    /// Also contains the type name of this value.
+    /// The format of the byte contents is explicitly unspecified.
+    /// Used for custom application data.
+    Bytes {
+
+        /// An application-specific type hint of the byte contents.
+        type_hint: Text,
+
+        /// The contents of this byte array are completely unspecified
+        /// and should be treated as untrusted data.
+        bytes: SmallVec<[u8; 16]>
+    },
+
     /// A custom attribute.
     /// Contains the type name of this value.
     Custom {
@@ -91,12 +105,12 @@ pub enum AttributeValue {
 
         /// The value, stored in little-endian byte order, of the value.
         /// Use the `exr::io::Data` trait to extract binary values from this vector.
-        bytes: Vec<u8>
+        bytes: SmallVec<[u8; 16]>
     },
 }
 
 /// A byte array with each byte being a char.
-/// This is not UTF an must be constructed from a standard string.
+/// This is not UTF and it must be constructed from a standard string.
 // TODO is this ascii? use a rust ascii crate?
 #[derive(Clone, PartialEq, Ord, PartialOrd, Default)] // hash implemented manually
 pub struct Text {
@@ -490,10 +504,22 @@ impl Text {
         self.bytes.len() + i32::BYTE_SIZE
     }
 
+    /// The byte count this string would occupy if it were encoded as a size-prefixed string.
+    pub fn u32_sized_byte_size(&self) -> usize {
+        self.bytes.len() + u32::BYTE_SIZE
+    }
+
     /// Write the length of a string and then the contents with that length.
     pub fn write_i32_sized_le<W: Write>(&self, write: &mut W) -> UnitResult {
         debug_assert!(self.validate( false, None).is_ok(), "text size bug");
         i32::write_le(usize_to_i32(self.bytes.len()), write)?;
+        Self::write_unsized_bytes(self.bytes.as_slice(), write)
+    }
+
+    /// Write the length of a string and then the contents with that length.
+    pub fn write_u32_sized_le<W: Write>(&self, write: &mut W) -> UnitResult {
+        debug_assert!(self.validate( false, None).is_ok(), "text size bug");
+        u32::write(usize_to_u32(self.bytes.len(), "text length")?, write)?;
         Self::write_unsized_bytes(self.bytes.as_slice(), write)
     }
 
@@ -507,6 +533,12 @@ impl Text {
     pub fn read_i32_sized_le<R: Read>(read: &mut R, max_size: usize) -> Result<Self> {
         let size = i32_to_usize(i32::read_le(read)?, "vector size")?;
         Ok(Text::from_bytes_unchecked(SmallVec::from_vec(u8::read_vec_le(read, size, 1024, Some(max_size), "text attribute length")?)))
+    }
+
+    /// Read the length of a string and then the contents with that length.
+    pub fn read_u32_sized_le<R: Read>(read: &mut R, max_size: usize) -> Result<Self> {
+        let size = u32_to_usize(u32::read_le(read)?);
+        Ok(Text::from_bytes_unchecked(SmallVec::from_vec(u8::read_vec(read, size, 1024, Some(max_size), "text attribute length")?)))
     }
 
     /// Read the contents with that length.
@@ -1688,7 +1720,10 @@ impl AttributeValue {
             TextVector(ref value) => value.iter().map(self::Text::i32_sized_byte_size).sum(),
             TileDescription(_) => self::TileDescription::byte_size(),
             Custom { ref bytes, .. } => bytes.len(),
-            BlockType(ref kind) => kind.byte_size()
+            BlockType(ref kind) => kind.byte_size(),
+
+            Bytes { ref bytes, ref type_hint } =>
+                type_hint.u32_sized_byte_size() + bytes.len(),
         }
     }
 
@@ -1722,6 +1757,7 @@ impl AttributeValue {
             TextVector(_) =>  ty::TEXT_VECTOR,
             TileDescription(_) =>  ty::TILES,
             BlockType(_) => super::BlockType::TYPE_NAME,
+            Bytes{ .. } => ty::BYTES,
             Custom { ref kind, .. } => kind.as_slice(),
         }
     }
@@ -1764,8 +1800,14 @@ impl AttributeValue {
 
             TextVector(ref value) => self::Text::write_vec_of_i32_sized_texts_le(write, value)?,
             TileDescription(ref value) => value.write(write)?,
-            Custom { ref bytes, .. } => u8::write_slice_le(write, &bytes)?, // write.write(&bytes).map(|_| ()),
-            BlockType(kind) => kind.write(write)?
+            BlockType(kind) => kind.write(write)?,
+
+            Bytes { ref type_hint, ref bytes } => {
+                type_hint.write_u32_sized_le(write)?; // no idea why this one is u32, everything else is usually i32...
+                u8::write_slice(write, bytes.as_slice())?
+            }
+
+            Custom { ref bytes, .. } => u8::write_slice(write, &bytes)?, // write.write(&bytes).map(|_| ()),
         };
 
         Ok(())
@@ -1773,15 +1815,17 @@ impl AttributeValue {
 
     /// Read the value without validating.
     /// Returns `Ok(Ok(attribute))` for valid attributes.
-    /// Returns `Ok(Err(Error))` for invalid attributes from a valid byte source.
+    /// Returns `Ok(Err(Error))` for malformed attributes from a valid byte source.
     /// Returns `Err(Error)` for invalid byte sources, for example for invalid files.
     pub fn read(read: &mut PeekRead<impl Read>, kind: Text, byte_size: usize) -> Result<Result<Self>> {
         use self::AttributeValue::*;
         use self::type_names as ty;
 
-        // always read bytes
-        let attribute_bytes = u8::read_vec_le(read, byte_size, 128, None, "attribute value size")?;
-        // TODO no allocation for small attributes // : SmallVec<[u8; 64]> = smallvec![0; byte_size];
+        // always read bytes as to leave the read position at the end of the attribute
+        // even if the attribute contents fails to decode
+        let mut attribute_bytes = SmallVec::<[u8; 64]>::new();
+        u8::read_into_vec_le(read, &mut attribute_bytes, byte_size, 64, None, "attribute value size")?;
+        // TODO: don't read into an array at all, just read directly from the reader and optionally seek afterwards?
 
         let parse_attribute = move || {
             let reader = &mut attribute_bytes.as_slice();
@@ -1859,7 +1903,14 @@ impl AttributeValue {
 
                 ty::TILES       => TileDescription(self::TileDescription::read(reader)?),
 
-                _ => Custom { kind: kind.clone(), bytes: attribute_bytes.clone() } // TODO no clone
+                ty::BYTES       => {
+                    // for some reason, they went for unsigned sizes, in this place only
+                    let type_hint = self::Text::read_u32_sized_le(reader, reader.len())?;
+                    let bytes = SmallVec::from(*reader);
+                    Bytes { type_hint, bytes }
+                }
+
+                _ => Custom { kind: kind.clone(), bytes: SmallVec::from(*reader) }
             })
         };
 
@@ -1972,7 +2023,8 @@ pub mod type_names {
         PREVIEW:        b"preview",
         TEXT:           b"string",
         TEXT_VECTOR:    b"stringvector",
-        TILES:          b"tiledesc"
+        TILES:          b"tiledesc",
+        BYTES:          b"bytes"
     }
 }
 
@@ -2106,6 +2158,13 @@ mod test {
                     size: Vec2(10, 30),
                     pixel_data: vec![31; 10 * 30 * 4],
                 }),
+            ),
+            (
+                Text::from("custom byte sequence: prime numbers single byte"),
+                AttributeValue::Bytes{
+                    type_hint: Text::from("byte-primes"),
+                    bytes: smallvec![2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,71,73],
+                },
             ),
             (
                 Text::from("leg count, again"),


### PR DESCRIPTION
- breaking: add 1 new variant `Attribute::Bytes`
- use smallvec to avoid small repeated allocations when reading each attribute