### PR TITLE
Add prepack script to fix broken npm publish

### DIFF
--- a/exrs-wasm/js/package.json
+++ b/exrs-wasm/js/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "prebuild": "cd .. && wasm-pack build --target web",
     "build": "npm i && tsc",
+    "prepack": "npm run build",
     "test": "npm run build && vitest run",
     "format": "prettier --write ."
   },


### PR DESCRIPTION
The `exrs` package (v1.0.2) fails to install due to an unresolvable `file:../pkg` dependency reference. The root cause is that `exrs-raw-wasm-bindgen` was listed in `bundledDependencies` but the full build was never run before publishing, so nothing was actually bundled in the tarball.

Adds a `prepack` lifecycle script that runs `npm run build` (wasm-pack → npm install → tsc) before packing, ensuring `node_modules/exrs-raw-wasm-bindgen` is populated and bundled correctly.